### PR TITLE
Swap out dhparam task with ansible role

### DIFF
--- a/ansible/group_vars/web-tls/vars
+++ b/ansible/group_vars/web-tls/vars
@@ -1,4 +1,7 @@
 ---
+dhparam_size: 2048
+dhparam_file: /etc/nginx/ssl/dhparam.pem
+
 letsencrypt_webroot_path: /usr/share/nginx/html
 letsencrypt_email: infrastructure@openmrs.org
 letsencrypt_renewal_command_args: '--renew-hook "systemctl restart nginx"'

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -2,6 +2,8 @@
 - name: datadog
   src: Datadog.datadog
   version: 1.3.0
+- name: dhparam
+  src: gronke.dhparam
 - name: docker
   src: andrewrothstein.docker
   version: v5.0.4

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -14,6 +14,7 @@
   tasks:
     - include: tasks/nginx-hacks.yml
   roles:
+    - dhparam
     - letsencrypt
 
 - hosts: web

--- a/ansible/tasks/nginx-hacks.yml
+++ b/ansible/tasks/nginx-hacks.yml
@@ -4,8 +4,3 @@
       state: 'directory'
       path: "/etc/nginx/ssl"
       mode: "0755"
-  - stat: path=/etc/nginx/ssl/dhparam.pem
-    register: dhparam_file
-  - name: 'Improve Key Exchange'
-    shell: openssl dhparam -out /etc/nginx/ssl/dhparam.pem 2048
-    when: dhparam_file.stat.exists == False


### PR DESCRIPTION
This swaps out the ansible task with an ansible role. The role optionally will also re-generate them in a cronjob -- default is weekly -- I enabled this. 