### PR TITLE
ITSM-4029 Fix bamboo home Backup

### DIFF
--- a/ansible/files/backups/pack-app-home-folders.sh
+++ b/ansible/files/backups/pack-app-home-folders.sh
@@ -7,6 +7,12 @@ echo "Packing application home folders $(date)"
 
 for file in $(find /data/ -maxdepth 1 -name "*_home"); do
   echo "Folder $file"
-  (cd $file
-  tar --exclude="./artifacts" -zcvf /opt/backups/$(basename $file)-$(date +\%Y-\%m-\%d_\%H-\%M-\%S).tar.gz .)
+  if [ $file = "/data/bamboo_home" ]
+  then
+    (cd $file
+     tar --exclude="./artifacts" -zcvf /opt/backups/$(basename $file)-$(date +\%Y-\%m-\%d_\%H-\%M-\%S).tar.gz .)
+  else
+    (cd $file
+    tar -czvf /opt/backups/$(basename $file)-$(date +\%Y-\%m-\%d_\%H-\%M-\%S).tar.gz .)
+  fi
 done


### PR DESCRIPTION
- Exclude artifacts instead of cache for bamboo backup.
- This will not affect the backup for others as artifacts folder is only present in bamboo.