### PR TITLE
ITSM-4265: Update maven version

### DIFF
--- a/bamboo-agents-puppet/hieradata/common.yaml
+++ b/bamboo-agents-puppet/hieradata/common.yaml
@@ -2,7 +2,7 @@
 bamboo_agent_home::bamboo_user: 'bamboo-agent'
 bamboo_agent_home::bamboo_user_home: '/home/bamboo-agent'
 
-profiles::java_buildtime::maven3_version: "3.2.5"
+profiles::java_buildtime::maven3_version: "3.6.3"
 profiles::ruby_buildtime::grails_version: '2.3.7'
 
 

--- a/bamboo-agents-puppet/spec/java_spec.rb
+++ b/bamboo-agents-puppet/spec/java_spec.rb
@@ -8,7 +8,7 @@ describe 'java builder machine' do
     expect(command('/usr/lib/jvm/java-1.7.0-openjdk-amd64/jre/bin/java -version').stderr).to include('1.7.0')
   end
   it 'should have mvn command' do
-    expect(command('mvn3 --version').stdout).to include('3.2.5')
+    expect(command('mvn3 --version').stdout).to include('3.6.3')
   end
   it 'should have mvn creds' do
     expect(command('fgrep "<password>" /home/bamboo-agent/.m2/settings.xml | uniq -c').stdout).to include('4       <password>amazingMavenTestPassword</password>')


### PR DESCRIPTION
This seems to be all that's necessary to get Maven upgraded on the Vagrant box.

@cintiadr Looking over [the ticket](https://issues.openmrs.org/browse/ITSM-4265), I think everything else is straight-forward to do. (Though I think I'll need access to the agents to remove do the middle steps)

The part I'm a little hesitant on is the MVN3 capability on the CI server. Currently, this is set to `/usr/share/apache-maven-3.2.5` which, at least on the Vagrant box is a directory that contains the expanded Maven ZIP (and this seems to be what is implied by the [java_buildtime.pp](https://github.com/openmrs/openmrs-contrib-itsmresources/blob/19b562f4ec7c44ff97522e7cf18f04101deb4975/bamboo-agents-puppet/openmrs-modules/profiles/manifests/java_buildtime.pp#L22), so I'm unsure if there's some Bamboo magic that finds the executable at `/usr/share/apache-maven-3.2.5/bin/mvn` and if so, can we safely change this to `/bin/mvn3` (setup [here](https://github.com/openmrs/openmrs-contrib-itsmresources/blob/19b562f4ec7c44ff97522e7cf18f04101deb4975/bamboo-agents-puppet/openmrs-modules/profiles/manifests/java_buildtime.pp#L28)) which would [be consistent with the other capabilities](https://ci.openmrs.org/admin/agent/viewAgent.action?agentId=133988353) for our build agents.