### PR TITLE
Configure datadog to ignore squashfs volumes

### DIFF
--- a/ansible/group_vars/all/vars
+++ b/ansible/group_vars/all/vars
@@ -86,6 +86,8 @@ datadog_checks:
           timeout: 8
   disk:
     init_config:
+        file_system_global_blacklist:
+            - squashfs
     instances:
         - service_check_rw: true
 


### PR DESCRIPTION
This PR fixes the many datadog alerts that having snap generates, due to how snap packages are mounted on a read-only volume of the exact size of the snap package.