### PR TITLE
Grant jayasanka access to sawla and adaba

### DIFF
--- a/ansible/host_vars/adaba.openmrs.org/vars
+++ b/ansible/host_vars/adaba.openmrs.org/vars
@@ -1,6 +1,12 @@
 ---
 # LDAP, ID, Crowd
 
+users:
+  jayasanka:
+    comment: Jayasanka Weerasinghe
+    groups: 'admin'
+    ssh_key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDAxRE0WsKB8J7Qkg3LiCaspqsYzIjuv2BTPnzywBlVs5LCyzDNpT2QqaJxlrI8fEucQFAzMSIPwgBV+HzhhQ3uoPbjALAhMkoxPHM8dVdqbvKIrIpJq3sOEw41GGWmP454aXqAv6YwGwxPpAF5w/46p1c81HXqpEYkDB5TN9u0tG7R/fY8eUt+bQcnqU+QJiThKp/vxCm8fBQ7O708A0WpK9zWYh0Ut2Oc3FhkdaFlA4HyHwfX+Yp4YDjVcpDxVPICvlEb8lLh8+H3Rm5Rk3gmOnXmKCEy7eqYD0LXJmqA//b6RhukZI/nUk5JnixtOXGhhKvd7ijoM42YlxtJu7bbiFyCmHUw3WLox+oEaOe4mHLqUBvmN+jeI9NY+XWHv2T7UQTCfch2EI9/eVLhFtepauBwhOnBOjwa7gQFBiV1RuI6j80pFv8BvciSc/LKhFcsAJStYt3pd841jA2+GBErNJowEuKBAYKrTZqD7SgneW0CzoHpu5hrPmhiZkjFIjGRhLs3LSjzHkl/efyEzmbkwjuVp5fmCnpkV4QIwS644ZMPTx1qXJ0uRSSnAsvlN+45+HhgFC2risS1h+LDzbBLib58xaz7OR1GhbymbA+EFoms2Pa5aN7MwcGLYEDLl1Ggk/zJ+u52/E66xsZHy6lRQJ2kriRDCWz/lgJZALOSIw== jayasanka@Jayasankas-MacBook-Pro.local"
+
 datadog_tags_extra:
   - "service:ldap"
   - "service:crowd"

--- a/ansible/host_vars/sawla.openmrs.org/vars
+++ b/ansible/host_vars/sawla.openmrs.org/vars
@@ -1,6 +1,13 @@
 ---
 
 # Database
+
+users:
+  jayasanka:
+    comment: Jayasanka Weerasinghe
+    groups: 'admin'
+    ssh_key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDAxRE0WsKB8J7Qkg3LiCaspqsYzIjuv2BTPnzywBlVs5LCyzDNpT2QqaJxlrI8fEucQFAzMSIPwgBV+HzhhQ3uoPbjALAhMkoxPHM8dVdqbvKIrIpJq3sOEw41GGWmP454aXqAv6YwGwxPpAF5w/46p1c81HXqpEYkDB5TN9u0tG7R/fY8eUt+bQcnqU+QJiThKp/vxCm8fBQ7O708A0WpK9zWYh0Ut2Oc3FhkdaFlA4HyHwfX+Yp4YDjVcpDxVPICvlEb8lLh8+H3Rm5Rk3gmOnXmKCEy7eqYD0LXJmqA//b6RhukZI/nUk5JnixtOXGhhKvd7ijoM42YlxtJu7bbiFyCmHUw3WLox+oEaOe4mHLqUBvmN+jeI9NY+XWHv2T7UQTCfch2EI9/eVLhFtepauBwhOnBOjwa7gQFBiV1RuI6j80pFv8BvciSc/LKhFcsAJStYt3pd841jA2+GBErNJowEuKBAYKrTZqD7SgneW0CzoHpu5hrPmhiZkjFIjGRhLs3LSjzHkl/efyEzmbkwjuVp5fmCnpkV4QIwS644ZMPTx1qXJ0uRSSnAsvlN+45+HhgFC2risS1h+LDzbBLib58xaz7OR1GhbymbA+EFoms2Pa5aN7MwcGLYEDLl1Ggk/zJ+u52/E66xsZHy6lRQJ2kriRDCWz/lgJZALOSIw== jayasanka@Jayasankas-MacBook-Pro.local"
+
 datadog_tags_extra:
   - "service:database"
 


### PR DESCRIPTION
I'm working on the wiki migration. 

I need access to sawla as I need to
- take a backup before the migration 
- run a raw query to update user emails
- restore the backup if things go wrong. 

Also, I re-added my new ssh key to `adaba` with this PR.

Check [this doc](https://docs.google.com/document/d/1UugkQTNS53RG5a8hRjLXq7LbTz-6B5QzTQf8efSLLTM/edit) to see full migration plan. 