### PR TITLE
Redirect wiki.openmrs.org to new wiki

### DIFF
--- a/ansible/host_vars/mota.openmrs.org/vars
+++ b/ansible/host_vars/mota.openmrs.org/vars
@@ -52,7 +52,7 @@ nginx_vhosts:
         return 301 https://openmrs.atlassian.net/wiki$request_uri;
       }
       location / {
-        return 301 https://openmrs.atlassian.net/wiki;
+        return 301 https://openmrs.atlassian.net/wiki/spaces/docs/overview;
       }
 
 aws_access_key_id: '{{ vault_aws_access_key_id }}'

--- a/ansible/host_vars/mota.openmrs.org/vars
+++ b/ansible/host_vars/mota.openmrs.org/vars
@@ -49,7 +49,7 @@ nginx_vhosts:
         root /usr/share/nginx/html;
       }
       location ^~ /display/ {
-        return 301 https://openmrs.atlassian.net$request_uri;
+        return 301 https://openmrs.atlassian.net/wiki$request_uri;
       }
       location / {
         return 301 https://openmrs.atlassian.net/wiki;

--- a/ansible/host_vars/mota.openmrs.org/vars
+++ b/ansible/host_vars/mota.openmrs.org/vars
@@ -48,25 +48,11 @@ nginx_vhosts:
       location ^~ /.well-known/acme-challenge/ {
         root /usr/share/nginx/html;
       }
-      location /forgotuserpassword.action {
-        return 302 https://id.openmrs.org/reset;
+      location ^~ /display/ {
+        return 301 https://openmrs.atlassian.net$request_uri;
       }
       location / {
-        client_max_body_size 100m;
-        proxy_set_header HOST $host;
-        proxy_set_header X-Forwarded-Server $host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header  X-Forwarded-Proto $scheme;
-        proxy_pass http://127.0.0.1:8090;
-      }
-      location /synchrony {
-          proxy_set_header X-Forwarded-Host $host;
-          proxy_set_header X-Forwarded-Server $host;
-          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-          proxy_pass http://localhost:8091/synchrony;
-          proxy_http_version 1.1;
-          proxy_set_header Upgrade $http_upgrade;
-          proxy_set_header Connection "Upgrade";
+        return 301 https://openmrs.atlassian.net/wiki;
       }
 
 aws_access_key_id: '{{ vault_aws_access_key_id }}'


### PR DESCRIPTION
The purpose of this PR is to redirect wiki.openmrs.org (and page links) to the Atlassian cloud site. 

ex: 
https://wiki.openmrs.org/display/docs/Introduction+to+OpenMRS

should be redirected to:

https://openmrs.atlassian.net/wiki/display/docs/Introduction+to+OpenMRS