### PR TITLE
feat: new ansible role that uses certbot to manage ssl certs for the …

### DIFF
--- a/ansible/custom_roles/certbot/defaults/main.yml
+++ b/ansible/custom_roles/certbot/defaults/main.yml
@@ -1,0 +1,56 @@
+---
+
+---
+# Certbot auto-renew cron job configuration (for certificate renewals).
+certbot_auto_renew: true
+certbot_auto_renew_user: "{{ ansible_user | default(lookup('env', 'USER')) }}"
+certbot_auto_renew_hour: "3"
+certbot_auto_renew_minute: "30"
+certbot_auto_renew_options: "--quiet"
+
+certbot_testmode: false
+certbot_hsts: false
+
+
+# Parameters used when creating new Certbot certs.
+certbot_create_if_missing: false
+certbot_create_method: standalone
+certbot_admin_email: infrastructure@openmrs.org
+
+# Default webroot, overwritten by individual per-cert webroot directories
+certbot_webroot: /var/www/letsencrypt
+
+certbot_certs: []
+# - domains:
+#     - dev-his.openmrs.org
+
+certbot_create_command: >-
+  {{ certbot_script }} certonly --{{ certbot_create_method  }}
+  {{ '--hsts' if certbot_hsts else '' }}
+  {{ '--test-cert' if certbot_testmode else '' }}
+  --noninteractive --agree-tos
+  --email {{ cert_item.email | default(certbot_admin_email) }}
+  {{ '--webroot-path ' if certbot_create_method == 'webroot'  else '' }}
+  {{ cert_item.webroot | default(certbot_webroot) if certbot_create_method == 'webroot' else '' }}
+  {{ certbot_create_extra_args }}
+  -d {{ cert_item.domains | join(',') }}
+  {{ '--pre-hook /etc/letsencrypt/renewal-hooks/pre/stop_services'
+    if certbot_create_standalone_stop_services and certbot_create_method == 'standalone'
+  else '' }}
+  {{ '--post-hook /etc/letsencrypt/renewal-hooks/post/start_services'
+    if certbot_create_standalone_stop_services and certbot_create_method == 'standalone'
+  else '' }}
+
+certbot_create_standalone_stop_services:
+  - nginx
+
+# Available options: 'package', 'snap', 'source'.
+certbot_install_method: 'package'
+
+# Source install configuration.
+certbot_repo: https://github.com/certbot/certbot.git
+certbot_version: master
+certbot_keep_updated: true
+
+# Where to put Certbot when installing from source.
+certbot_dir: /opt/certbot

--- a/ansible/custom_roles/certbot/meta/main.yml
+++ b/ansible/custom_roles/certbot/meta/main.yml
@@ -1,0 +1,30 @@
+---
+dependencies: []
+
+galaxy_info:
+  role_name: certbot
+  author: geerlingguy
+  description: "Installs and configures Certbot (for Let's Encrypt)."
+  company: "Midwestern Mac, LLC"
+  license: "license (BSD, MIT)"
+  min_ansible_version: 2.10
+  platforms:
+    - name: Fedora
+      versions:
+        - all
+    - name: Ubuntu
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
+  galaxy_tags:
+    - networking
+    - system
+    - web
+    - certbot
+    - letsencrypt
+    - encryption
+    - certificates
+    - ssl
+    - https

--- a/ansible/custom_roles/certbot/tasks/create-cert-standalone.yml
+++ b/ansible/custom_roles/certbot/tasks/create-cert-standalone.yml
@@ -1,0 +1,42 @@
+---
+- name: Check if certificate already exists.
+  stat:
+    path: /etc/letsencrypt/live/{{ cert_item.domains | first | replace('*.', '') }}/cert.pem
+  register: letsencrypt_cert
+
+- name: Ensure pre and post hook folders exist.
+  file:
+    path: /etc/letsencrypt/renewal-hooks/{{ item }}
+    state: directory
+    mode: 0755
+    owner: root
+    group: root
+  with_items:
+    - pre
+    - post
+
+- name: Create pre hook to stop services.
+  template:
+    src: stop_services.j2
+    dest: /etc/letsencrypt/renewal-hooks/pre/stop_services
+    owner: root
+    group: root
+    mode: 0750
+  when:
+    - certbot_create_standalone_stop_services is defined
+    - certbot_create_standalone_stop_services
+
+- name: Create post hook to start services.
+  template:
+    src: start_services.j2
+    dest: /etc/letsencrypt/renewal-hooks/post/start_services
+    owner: root
+    group: root
+    mode: 0750
+  when:
+    - certbot_create_standalone_stop_services is defined
+    - certbot_create_standalone_stop_services
+
+- name: Generate new certificate if one doesn't exist.
+  command: "{{ certbot_create_command }}"
+  when: not letsencrypt_cert.stat.exists

--- a/ansible/custom_roles/certbot/tasks/create-cert-webroot.yml
+++ b/ansible/custom_roles/certbot/tasks/create-cert-webroot.yml
@@ -1,0 +1,14 @@
+---
+- name: Check if certificate already exists.
+  stat:
+    path: /etc/letsencrypt/live/{{ cert_item.domains | first }}/cert.pem
+  register: letsencrypt_cert
+
+- name: Create webroot directory if it doesn't exist yet
+  file:
+    path: "{{ cert_item.webroot | default(certbot_webroot) }}"
+    state: directory
+
+- name: Generate new certificate if one doesn't exist.
+  command: "{{ certbot_create_command }}"
+  when: not letsencrypt_cert.stat.exists

--- a/ansible/custom_roles/certbot/tasks/include-vars.yml
+++ b/ansible/custom_roles/certbot/tasks/include-vars.yml
@@ -1,0 +1,8 @@
+---
+- name: Load a variable file based on the OS type, or a default if not found.
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_distribution }}-{{ ansible_distribution_version }}.yml"
+    - "{{ ansible_distribution }}.yml"
+    - "{{ ansible_os_family }}.yml"
+    - "default.yml"

--- a/ansible/custom_roles/certbot/tasks/install-from-source.yml
+++ b/ansible/custom_roles/certbot/tasks/install-from-source.yml
@@ -1,0 +1,17 @@
+---
+- name: Clone Certbot into configured directory.
+  git:
+    repo: "{{ certbot_repo }}"
+    dest: "{{ certbot_dir }}"
+    version: "{{ certbot_version }}"
+    update: "{{ certbot_keep_updated }}"
+    force: true
+
+- name: Set Certbot script variable.
+  set_fact:
+    certbot_script: "{{ certbot_dir }}/certbot-auto"
+
+- name: Ensure certbot-auto is executable.
+  file:
+    path: "{{ certbot_script }}"
+    mode: 0755

--- a/ansible/custom_roles/certbot/tasks/install-with-package.yml
+++ b/ansible/custom_roles/certbot/tasks/install-with-package.yml
@@ -1,0 +1,7 @@
+---
+- name: Install Certbot.
+  package: "name={{ certbot_package }} state=present"
+
+- name: Set Certbot script variable.
+  set_fact:
+    certbot_script: "{{ certbot_package }}"

--- a/ansible/custom_roles/certbot/tasks/install-with-snap.yml
+++ b/ansible/custom_roles/certbot/tasks/install-with-snap.yml
@@ -1,0 +1,41 @@
+---
+- name: Ensure snapd is installed.
+  package:
+    name: snapd
+    state: present
+  register: snapd_install
+
+- name: Ensure snapd is enabled.
+  systemd:
+    name: snapd.socket
+    enabled: true
+    state: started
+
+- name: Enable classic snap support.
+  file:
+    src: /var/lib/snapd/snap
+    dest: /snap
+    state: link
+  when: ansible_os_family != "Debian"
+
+- name: Update snap after install.
+  shell: snap install core; snap refresh core
+  changed_when: true
+  failed_when: false
+  when: snapd_install is changed
+
+- name: Install certbot via snap.
+  snap:
+    name: certbot
+    classic: true
+
+- name: Symlink certbot into place.
+  file:
+    src: /snap/bin/certbot
+    dest: /usr/bin/certbot
+    state: link
+  ignore_errors: "{{ ansible_check_mode }}"
+
+- name: Set Certbot script variable.
+  set_fact:
+    certbot_script: /usr/bin/certbot

--- a/ansible/custom_roles/certbot/tasks/main.yml
+++ b/ansible/custom_roles/certbot/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+- import_tasks: include-vars.yml
+
+- import_tasks: setup-RedHat.yml
+  when: ansible_os_family == 'RedHat'
+
+- import_tasks: install-with-package.yml
+  when: certbot_install_method == 'package'
+
+- import_tasks: install-with-snap.yml
+  when: certbot_install_method == 'snap'
+
+- import_tasks: install-from-source.yml
+  when: certbot_install_method == 'source'
+
+- include_tasks: create-cert-standalone.yml
+  with_items: "{{ certbot_certs }}"
+  when:
+    - certbot_create_if_missing
+    - certbot_create_method == 'standalone'
+  loop_control:
+    loop_var: cert_item
+
+- include_tasks: create-cert-webroot.yml
+  with_items: "{{ certbot_certs }}"
+  when:
+    - certbot_create_if_missing
+    - certbot_create_method == 'webroot'
+  loop_control:
+    loop_var: cert_item
+
+- import_tasks: renew-cron.yml
+  when: certbot_auto_renew

--- a/ansible/custom_roles/certbot/tasks/renew-cron.yml
+++ b/ansible/custom_roles/certbot/tasks/renew-cron.yml
@@ -1,0 +1,17 @@
+---
+- name: Clone Certbot into configured directory.
+  git:
+    repo: "{{ certbot_repo }}"
+    dest: "{{ certbot_dir }}"
+    version: "{{ certbot_version }}"
+    update: "{{ certbot_keep_updated }}"
+    force: true
+
+- name: Set Certbot script variable.
+  set_fact:
+    certbot_script: "{{ certbot_dir }}/certbot-auto"
+
+- name: Ensure certbot-auto is executable.
+  file:
+    path: "{{ certbot_script }}"
+    mode: 0755

--- a/ansible/custom_roles/certbot/tasks/setup-Redhat.yml
+++ b/ansible/custom_roles/certbot/tasks/setup-Redhat.yml
@@ -1,0 +1,11 @@
+---
+# See: https://github.com/geerlingguy/ansible-role-certbot/issues/107
+- name: Ensure dnf-plugins are installed on Rocky/AlmaLinux.
+  yum:
+    name: dnf-plugins-core
+    state: present
+
+- name: Enable DNF module for Rocky/AlmaLinux.
+  shell: |
+    dnf config-manager --set-enabled crb
+  changed_when: false

--- a/ansible/custom_roles/certbot/templates/start_services.j2
+++ b/ansible/custom_roles/certbot/templates/start_services.j2
@@ -1,0 +1,15 @@
+#!/bin/bash
+# {{ ansible_managed }}
+
+{% for item in certbot_create_standalone_stop_services %}
+echo "starting service {{ item }}"
+{% if ansible_service_mgr == 'systemd' %}
+systemctl start {{ item }}
+{% elif ansible_service_mgr == 'upstart' %}
+initctl start {{ item }}
+{% elif ansible_service_mgr == 'openrc' %}
+rc-service {{ item }} start
+{% else %}
+service {{ item }} start
+{% endif %}
+{% endfor %}

--- a/ansible/custom_roles/certbot/templates/stop_services.j2
+++ b/ansible/custom_roles/certbot/templates/stop_services.j2
@@ -1,0 +1,15 @@
+#!/bin/bash
+# {{ ansible_managed }}
+
+{% for item in certbot_create_standalone_stop_services %}
+echo "stopping service {{ item }}"
+{% if ansible_service_mgr == 'systemd' %}
+systemctl stop {{ item }}
+{% elif ansible_service_mgr == 'upstart' %}
+initctl stop {{ item }}
+{% elif ansible_service_mgr == 'openrc' %}
+rc-service {{ item }} stop
+{% else %}
+service {{ item }} stop
+{% endif %}
+{% endfor %}

--- a/ansible/custom_roles/certbot/vars/default.yml
+++ b/ansible/custom_roles/certbot/vars/default.yml
@@ -1,0 +1,2 @@
+---
+certbot_package: certbot

--- a/ansible/custom_roles/certbot/vars/ubuntu-18.04.yml
+++ b/ansible/custom_roles/certbot/vars/ubuntu-18.04.yml
@@ -1,0 +1,2 @@
+---
+certbot_package: letsencrypt

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -44,6 +44,14 @@
   handlers:
     - import_tasks: handlers/monitoring.yml
 
+- hosts: certbot
+  tags:
+    - certbot
+  tasks:
+    - import_tasks: tasks/main.yml
+  roles:
+   - certbot
+
 - hosts: web
   become: true
   tags:


### PR DESCRIPTION
This PR contains an ansible SSL role that is meant to use certbot to generate new ssl certs and handle auto renewal on existing and new machines.

This is pending testing.