### PR TITLE
INFRA-60: allowing ip updater in postfix to expose health checks

### DIFF
--- a/ansible/host_vars/adaba.openmrs.org/vars
+++ b/ansible/host_vars/adaba.openmrs.org/vars
@@ -104,6 +104,24 @@ nginx_vhosts:
         proxy_pass http://127.0.0.1:8080/;
       }
   - listen: "80"
+    server_name: "smtp.openmrs.org"
+    filename: "smtp.openmrs.org.80.conf"
+    extra_parameters: |
+      return 301 https://$host$request_uri;
+  - listen: "443 ssl"
+    server_name: "smtp.openmrs.org"
+    extra_parameters: |
+      access_log /var/log/nginx/smtp_access.log;
+      error_log /var/log/nginx/smtp_error.log;
+      ssl_certificate /etc/letsencrypt/live/adaba.openmrs.org/fullchain.pem;
+      ssl_certificate_key /etc/letsencrypt/live/adaba.openmrs.org/privkey.pem;
+      location ^~ /.well-known/acme-challenge/ {
+        root /usr/share/nginx/html;
+      }
+      location / {
+        proxy_pass http://localhost:8090/;
+      }
+  - listen: "80"
     server_name: "adaba.openmrs.org"
     filename: "adaba.openmrs.org.80.conf"
     extra_parameters: |

--- a/ansible/host_vars/gode.openmrs.org/vars
+++ b/ansible/host_vars/gode.openmrs.org/vars
@@ -86,14 +86,23 @@ nginx_vhosts:
         proxy_set_header  X-Forwarded-Host  $host;
         proxy_pass http://127.0.0.1:8080/;
       }
-      location /postfix {
-        proxy_pass http://localhost:8090;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Host $host;
-        proxy_set_header X-Forwarded-Port $server_port;
+  - listen: "80"
+    server_name: "smtp-stg.openmrs.org"
+    filename: "smtp-stg.openmrs.org.80.conf"
+    extra_parameters: |
+      return 301 https://$host$request_uri;
+  - listen: "443 ssl"
+    server_name: "smtp-stg.openmrs.org"
+    extra_parameters: |
+      access_log /var/log/nginx/smtp_access.log;
+      error_log /var/log/nginx/smtp_error.log;
+      ssl_certificate /etc/letsencrypt/live/gode.openmrs.org/fullchain.pem;
+      ssl_certificate_key /etc/letsencrypt/live/gode.openmrs.org/privkey.pem;
+      location ^~ /.well-known/acme-challenge/ {
+        root /usr/share/nginx/html;
+      }
+      location / {
+        proxy_pass http://localhost:8090/;
       }
   - listen: "80"
     server_name: "atlas-stg.openmrs.org"


### PR DESCRIPTION
Depends on https://github.com/openmrs/openmrs-contrib-ansible-docker-compose/pull/73 and https://github.com/openmrs/openmrs-contrib-itsm-id/pull/4

It seems our nginx role currently doesn't push config changes. 

But the idea is that we can use pingdom to check the status on this endpoint, and send notifications to status page if this doesn't work