### PR TITLE
INFRA-118: Limit BuildKit Caching on agents

### DIFF
--- a/ansible/files/docker/buildkitd.toml
+++ b/ansible/files/docker/buildkitd.toml
@@ -1,0 +1,28 @@
+[worker.containerd]
+  platforms = [ "linux/amd64", "linux/arm64" ]
+
+  # gc enables/disables garbage collection
+  gc = true
+  # reservedSpace is the minimum amount of disk space guaranteed to be
+  # retained by this buildkit worker - any usage below this threshold will not
+  # be reclaimed during garbage collection.
+  # all disk space parameters can be an integer number of bytes (e.g.
+  # 512000000), a string with a unit (e.g. "512MB"), or a string percentage
+  # of the total disk space (e.g. "10%")
+  reservedSpace = "10GB"
+  # maxUsedSpace is the maximum amount of disk space that may be used by
+  # this buildkit worker - any usage above this threshold will be reclaimed
+  # during garbage collection.
+  maxUsedSpace = "50GB"
+  # minFreeSpace is the target amount of free disk space that the garbage
+  # collector will attempt to leave - however, it will never be bought below
+  # reservedSpace.
+  minFreeSpace = "20GB"
+
+  [[worker.containerd.gcpolicy]]
+    reservedSpace = "512MB"
+    keepDuration = 172800
+    filters = [ "type==source.local", "type==exec.cachemount", "type==source.git.checkout"]
+  [[worker.containerd.gcpolicy]]
+    all = true
+    reservedSpace = "1GB"

--- a/ansible/tasks/docker-buildx.yml
+++ b/ansible/tasks/docker-buildx.yml
@@ -3,3 +3,40 @@
     apt:
       name: docker-buildx
       state: present
+
+  - name: Stop docker service
+    command: systemctl stop docker.service
+    when: docker_unconfigured_data_dir.rc != 0
+
+  - name: Stop docker socket
+    command: systemctl stop docker.socket
+    when: docker_unconfigured_data_dir.rc != 0
+
+  - name: Ensure BuildKit configuration directory exists
+    file:
+      path: /etc/buildkit
+      state: directory
+      owner: root
+      group: root
+      mode: 0755
+
+  - name: Configure BuildKit Caching
+    copy:
+      owner: root
+      group: root
+      mode: 0644
+      src: files/docker/buildkitd.toml
+      dest: /etc/buildkit/buildkitd.toml
+      force: false
+
+  - name: Reload docker service
+    command: systemctl daemon-reload
+    when: docker_unconfigured_data_dir.rc != 0
+
+  - name: Start docker socket service
+    command: systemctl start docker.socket
+    when: docker_unconfigured_data_dir.rc != 0
+
+  - name: Start docker service
+    command: systemctl start docker.service
+    when: docker_unconfigured_data_dir.rc != 0


### PR DESCRIPTION
Adds a (somewhat limited) `buildkitd.toml` file largely intended for the Bamboo agents, but usable anywhere else we use BuildKit.

This is basically a couple of config stanzas from [the example](https://docs.docker.com/build/buildkit/toml-configuration/), but I've turned the space sizes into MB / GB rather than percentages or bytes.