### PR TITLE
Add worker.oci to buildkitd.toml

### DIFF
--- a/ansible/files/docker/buildkitd.toml
+++ b/ansible/files/docker/buildkitd.toml
@@ -26,3 +26,32 @@
   [[worker.containerd.gcpolicy]]
     all = true
     reservedSpace = "1GB"
+
+[worker.oci]
+  platforms = [ "linux/amd64", "linux/arm64" ]
+
+  # gc enables/disables garbage collection
+  gc = true
+  # reservedSpace is the minimum amount of disk space guaranteed to be
+  # retained by this buildkit worker - any usage below this threshold will not
+  # be reclaimed during garbage collection.
+  # all disk space parameters can be an integer number of bytes (e.g.
+  # 512000000), a string with a unit (e.g. "512MB"), or a string percentage
+  # of the total disk space (e.g. "10%")
+  reservedSpace = "10GB"
+  # maxUsedSpace is the maximum amount of disk space that may be used by
+  # this buildkit worker - any usage above this threshold will be reclaimed
+  # during garbage collection.
+  maxUsedSpace = "50GB"
+  # minFreeSpace is the target amount of free disk space that the garbage
+  # collector will attempt to leave - however, it will never be bought below
+  # reservedSpace.
+  minFreeSpace = "20GB"
+
+  [[worker.oci.gcpolicy]]
+    reservedSpace = "512MB"
+    keepDuration = 172800
+    filters = [ "type==source.local", "type==exec.cachemount", "type==source.git.checkout"]
+  [[worker.oci.gcpolicy]]
+    all = true
+    reservedSpace = "1GB"


### PR DESCRIPTION
Xindi is using again 87 GB for docker. It appears that worker.containerd is not used in our CI. I'm adding worker.oci config.