### PR TITLE
HIS-11: Increase Proxy buffers to address an issue with upstream Keycoak header for HIS Dev

### DIFF
--- a/ansible/host_vars/dimtu.openmrs.org/vars
+++ b/ansible/host_vars/dimtu.openmrs.org/vars
@@ -177,6 +177,9 @@ nginx_vhosts:
         proxy_set_header  X-Real-IP $remote_addr;
         proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_pass http://127.0.0.1:8082/;
+        proxy_buffer_size 128k;
+        proxy_buffers 8 128k;
+        proxy_busy_buffers_size 256k;
       }
   - listen: "80"
     server_name: "dev3-orig.openmrs.org"


### PR DESCRIPTION
The PR addresses an error we are seeing when using SSO for Open HIS.  Upstream sent a too big header while reading the response header from upstream. Upstream server is Keycloak.