### PR TITLE
Add extra proxy headers to `auth.dev-his.openmrs.org` for improved request forwarding

### DIFF
--- a/ansible/host_vars/dimtu.openmrs.org/vars
+++ b/ansible/host_vars/dimtu.openmrs.org/vars
@@ -181,6 +181,9 @@ nginx_vhosts:
         proxy_set_header  X-Forwarded-Proto $scheme;
         proxy_set_header  X-Real-IP $remote_addr;
         proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header  X-Forwarded-Host $host;
+        proxy_set_header  X-Forwarded-Server $host;
+        proxy_set_header  X-Forwarded-Port $server_port;
         proxy_pass http://127.0.0.1:8084/;
         proxy_buffer_size 256k;
         proxy_buffers 4 512k;


### PR DESCRIPTION
Issue: https://openmrs.atlassian.net/browse/HIS-19

This PR adds Nginx extra headers to `auth.dev-his.openmrs.org` to help Keycloak determine the original request context. This is to fix the issue where Keycloak fails to load account console UI. 